### PR TITLE
Add project organization and roles

### DIFF
--- a/content/maintainers-guide/project-organization.md
+++ b/content/maintainers-guide/project-organization.md
@@ -43,7 +43,6 @@ Current UX designers:
 - Scott Cosio ([@prestascott](https://github.com/prestascott))
 - Tristan Lehot ([@TristanLDD](https://github.com/TristanLDD))
 
-### Quality Assurance (QA)
 ### Issue Managers
 
 Issue managers reproduce and qualify new issues to avoid duplicates and, if they are indeed defects in the software, their severity. They also redirect new improvement suggestions to the right Product Manager.
@@ -85,5 +84,13 @@ Current Software Developers in Test:
 Wording managers ensure that wordings are adequate, follow the project's tone of voice, and are categorized properly.
 
 Current wording managers:
+
+- Julie Varisellaz ([@Julievrz](https://github.com/Julievrz))
+
+### User Documentation Managers
+
+User documentation managers ensure the quality and consistency of the [user documentation](https://docs.prestashop-project.org/).
+
+Current user documentation managers:
 
 - Julie Varisellaz ([@Julievrz](https://github.com/Julievrz))

--- a/content/maintainers-guide/project-organization.md
+++ b/content/maintainers-guide/project-organization.md
@@ -1,0 +1,85 @@
+---
+title: Project organization
+weight: 1
+---
+
+# Project organization
+
+## Project roles
+
+### Product Manager
+
+Product Managers provide the project's product vision, ensuring that the software provides an answer to the needs of its different types of users.
+
+Current product managers:
+
+- Fabien Vallon ([@fabienvallon](https://github.com/fabienvallon))
+- Marion François ([@marionf](https://github.com/marionf))
+- Mateus Shirlaw ([@MatShir](https://github.com/MatShir))
+
+### Maintainer
+
+Maintainers provide the project's technical vision, review code contributions, and ensure that the software develops in line with the product vision.
+
+Current maintainers:
+
+- Franck Lefèvre ([@Progi1984](https://github.com/Progi1984))
+- Ibrahima Sow ([@sowbiba](https://github.com/sowbiba))
+- Jonathan Lelièvre ([@jolelievre](https://github.com/jolelievre))
+- Krystian Podemski ([@kpodemski](https://github.com/kpodemski))
+- Mathieu Ferment ([@matks](https://github.com/matks))
+- Matthieu Rolland ([@matthieu-rolland](https://github.com/matthieu-rolland))
+- Pablo Borowicz ([@eternoendless](https://github.com/eternoendless))
+- Pierre Rambaud ([@PierreRambaud](https://github.com/PierreRambaud))
+- Pululu Kinanga André ([@PululuK](https://github.com/PululuK))
+- Thomas Baccelli ([@atomiix](https://github.com/atomiix))
+- Valentin Szczupak ([@NeOMakinG](https://github.com/NeOMakinG))
+
+### UX Designer
+
+UX Designers make sure that interfaces follow the best practices in usability and design.
+
+Current UX designers:
+
+- Scott Cosio ([@prestascott](https://github.com/prestascott))
+- Tristan Lehot ([@TristanLDD](https://github.com/TristanLDD))
+
+### Quality Assurance (QA)
+
+Issue managers qualify new issues to avoid duplicates and, if they are indeed defects in the software, their severity.
+
+Current issue managers:
+
+- Florine Hea ([@florine2623](https://github.com/florine2623))
+- Hana Rebai ([@HanaRebaiQA](https://github.com/HanaRebaiQA))
+- Hibatallah Aouadni ([@hibatallahAouadni](https://github.com/hibatallahAouadni))
+- Khouloud Belguith ([@khouloudbelguith](https://github.com/khouloudbelguith))
+- Marwa Chelly ([@marwachelly](https://github.com/marwachelly))
+
+QA analysts make sure that the quality of the software improves over time, by verifying that code changes behave as expected.
+
+Current QA analysts:
+
+- Florine Hea ([@florine2623](https://github.com/florine2623))
+- Hana Rebai ([@HanaRebaiQA](https://github.com/HanaRebaiQA))
+- Hibatallah Aouadni ([@hibatallahAouadni](https://github.com/hibatallahAouadni))
+- Khouloud Belguith ([@khouloudbelguith](https://github.com/khouloudbelguith))
+- Marwa Chelly ([@marwachelly](https://github.com/marwachelly))
+- Robin Fischer ([@Robin-Fischer-PS](https://github.com/Robin-Fischer-PS))
+- Sarah Dib ([@sarahdib](https://github.com/sarahdib))
+
+QA automation engineers write automated functional tests, which help accelerate the work of QA analysts.
+
+Current QA automation engineers:
+
+- Nesrine Abdmouleh ([@nesrineabdmouleh](https://github.com/nesrineabdmouleh))
+- Stéphane Decisy ([@SD1982](https://github.com/SD1982))
+- Boubker Bribri ([@boubkerbribri](https://github.com/boubkerbribri))
+
+### Wording Manager
+
+Wording managers ensure that wordings are adequate, follow the project's tone of voice, and are categorized properly.
+
+Current wording managers:
+
+- Julie Varisellaz ([@Julievrz](https://github.com/Julievrz))

--- a/content/maintainers-guide/project-organization.md
+++ b/content/maintainers-guide/project-organization.md
@@ -7,18 +7,18 @@ weight: 1
 
 ## Project roles
 
-### Product Manager
+### Product Managers
 
-Product Managers provide the project's product vision, ensuring that the software provides an answer to the needs of its different types of users.
+Product Managers provide the product vision for the project, ensuring that the software meets the needs of its various users.
 
 Current product managers:
 
 - Fabien Vallon ([@fabienvallon](https://github.com/fabienvallon))
 - Mateus Shirlaw ([@MatShir](https://github.com/MatShir))
 
-### Maintainer
+### Maintainers
 
-Maintainers provide the project's technical vision, review code contributions, and ensure that the software develops in line with the product vision.
+Maintainers provide the technical vision for the project, review code contributions, and ensure that the software is developed according to the product vision.
 
 Current maintainers:
 
@@ -34,7 +34,7 @@ Current maintainers:
 - Thomas Baccelli ([@atomiix](https://github.com/atomiix))
 - Valentin Szczupak ([@NeOMakinG](https://github.com/NeOMakinG))
 
-### UX Designer
+### UX Designers
 
 UX Designers make sure that interfaces follow the best practices in usability and design.
 
@@ -44,8 +44,9 @@ Current UX designers:
 - Tristan Lehot ([@TristanLDD](https://github.com/TristanLDD))
 
 ### Quality Assurance (QA)
+### Issue Managers
 
-Issue managers qualify new issues to avoid duplicates and, if they are indeed defects in the software, their severity.
+Issue managers reproduce and qualify new issues to avoid duplicates and, if they are indeed defects in the software, their severity. They also redirect new improvement suggestions to the right Product Manager.
 
 Current issue managers:
 
@@ -55,9 +56,11 @@ Current issue managers:
 - Khouloud Belguith ([@khouloudbelguith](https://github.com/khouloudbelguith))
 - Marwa Chelly ([@marwachelly](https://github.com/marwachelly))
 
-QA analysts make sure that the quality of the software improves over time, by verifying that code changes behave as expected.
+### Software Testers
 
-Current QA analysts:
+Software Testers make sure that the quality of the software improves over time, by verifying that code changes behave as expected. To do this, they extensively test Pull Requests, PrestaShop's releases and its built-in modules.
+
+Current Software Testers:
 
 - Florine Hea ([@florine2623](https://github.com/florine2623))
 - Hana Rebai ([@HanaRebaiQA](https://github.com/HanaRebaiQA))
@@ -67,9 +70,11 @@ Current QA analysts:
 - Robin Fischer ([@Robin-Fischer-PS](https://github.com/Robin-Fischer-PS))
 - Sarah Dib ([@sarahdib](https://github.com/sarahdib))
 
-QA automation engineers write automated functional tests, which help accelerate the work of QA analysts.
+### Software Developers in Test
 
-Current QA automation engineers:
+Software Developers in Test provide technical vision, review contribution and write automated tests, which help accelerate the testing process.
+
+Current Software Developers in Test:
 
 - Nesrine Abdmouleh ([@nesrineabdmouleh](https://github.com/nesrineabdmouleh))
 - Stéphane Decisy ([@SD1982](https://github.com/SD1982))

--- a/content/maintainers-guide/project-organization.md
+++ b/content/maintainers-guide/project-organization.md
@@ -14,7 +14,6 @@ Product Managers provide the project's product vision, ensuring that the softwar
 Current product managers:
 
 - Fabien Vallon ([@fabienvallon](https://github.com/fabienvallon))
-- Marion François ([@marionf](https://github.com/marionf))
 - Mateus Shirlaw ([@MatShir](https://github.com/MatShir))
 
 ### Maintainer


### PR DESCRIPTION
I added this page to provide some visibility on what the roles are about and by who is doing the work. This can be iterated on afterward.

For now, I'd prefer to describe the roles as succinctly as possible, but the actual descriptions are approximate and most certainly need to be corrected by the people who do it, so I'm looking forward to your feedback!