### PR TITLE
Add link to thislg/local-php-security-checker-installer

### DIFF
--- a/content/maintainers-guide/releasing-prestashop/preliminary-tasks.md
+++ b/content/maintainers-guide/releasing-prestashop/preliminary-tasks.md
@@ -88,7 +88,7 @@ Make sure that in the current branch:
   php bin/console prestashop:linter:legacy-link
   ```
   
-* There are no known vulnerabilities in composer dependencies using [Fabpot Local PHP Security Checker][security-checker]
+* There are no known vulnerabilities in composer dependencies using [Fabpot Local PHP Security Checker][security-checker]. Consider using [this][security-checker-installer] if installing Fabpot Security Checker proves troublesome.
 
 * _(Minor and major releases only)_ – No important `@todo` annotations have been left forgotten in new code
 
@@ -126,3 +126,4 @@ If any of above verifications fails, it MUST be addressed in a Pull Requests and
 [fos-js-routing]: https://github.com/FriendsOfSymfony/FOSJsRoutingBundle
 [how-to-build-assets]: {{< devdocs "development/compile-assets/" >}}
 [nightly-build-board]: https://nightly.prestashop.com/
+[security-checker-installer]: https://github.com/thislg/local-php-security-checker-installer


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop Project Site! 

Please take the time to edit the "Answers" rows below with the necessary information.
Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you!
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description  | On Mac OS X it's sometimes troublesome to setup Local PHP Security Checker.
| Fixed ticket | 
