### PR TITLE
Add that 410 could only be used with Productv2

### DIFF
--- a/content/releases/prestashop80.md
+++ b/content/releases/prestashop80.md
@@ -327,7 +327,7 @@ downloadUrl: https://github.com/PrestaShop/PrestaShop/releases/
                                 <strong>Additional description for categories:</strong> enhance your category pages’ visibility by including a block of search engine optimized text at the bottom of the page.
                             </p>
                             <p>
-                                <strong>Prevent search engine crawlers from indexing discontinued products</strong> by setting up the “410 – Gone” status code on your discontinued products, instead of using “404 – Not Found”.
+                                <strong>Prevent search engine crawlers from indexing discontinued products</strong> by setting up the “410 – Gone” status code on your discontinued products, instead of using “404 – Not Found”. (Only with Product page v2)
                             </p>
                         </div>
                         <div class="col-md-6">


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop Project Site! 

Please take the time to edit the "Answers" rows below with the necessary information.
Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you!
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description  | 410 gone feature is not usable on v1.
