### PR TITLE
Removed useless notice for PrestaShop 8.x

### DIFF
--- a/content/maintainers-guide/releasing-prestashop/preliminary-tasks.md
+++ b/content/maintainers-guide/releasing-prestashop/preliminary-tasks.md
@@ -10,6 +10,10 @@ Before you can start your build, you must make sure that the project is ready to
 ## 1. Create the new version in Addons Marketplace and update native module compatibility
 
 {{% notice warning %}}
+**Only for PrestaShop 1.7.x releases.**
+{{% /notice %}}
+
+{{% notice warning %}}
 **This step requires special rights.**
 
 Ask a maintainer from the PrestaShop Company with administrative rights on the Addons Marketplace to perform this step.

--- a/content/maintainers-guide/releasing-prestashop/preliminary-tasks.md
+++ b/content/maintainers-guide/releasing-prestashop/preliminary-tasks.md
@@ -48,11 +48,6 @@ Check the following files and update them if necessary:
     const MINOR_VERSION = 6;
     const RELEASE_VERSION = 2;
     ```
-    
-{{% notice tip %}}
-Starting with Prestashop 8.1, version constants are located in `src/Core/Version.php`.
-{{% /notice %}}
-
 
 Make a pull request and have it merged.
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description  | The notice for 8.x is useless. 
| Fixed ticket | ~

Maybe I'm wrong, but in `src/Core/Foundation/Version.php` (and not `src/Core/Version.php`, there is no version constants. 