### PR TITLE
Add security section

### DIFF
--- a/content/security/_index.md
+++ b/content/security/_index.md
@@ -1,0 +1,14 @@
+---
+title: Security
+menu:
+  main:
+    parent: "Resources"
+    name: "Security"
+---
+
+# Project security
+
+This section describes security matters for the project.
+
+{{% children /%}}
+

--- a/content/security/bug-bounty.md
+++ b/content/security/bug-bounty.md
@@ -1,0 +1,17 @@
+---
+title: Bug Bounty
+---
+
+# Bug bounty
+
+A bug bounty for security flaws is hosted on YesWeHack platform.
+
+{{% notice warning %}}
+On the 25th of May 2023, due to a high number of vulnerabilities reported recently, we are pausing the program for now in order to be able to process them qualitatively.
+{{% /notice %}}
+<a class="btn btn-warning" style="margin: 2rem auto" href="https://yeswehack.com/programs/prestashop">Visit the Bug Bounty page</a>
+{.text-center}
+
+This bounty program covers code from the GitHub repository PrestaShop/PrestaShop and all PrestaShop modules defined in the composer.json file.
+
+Informations about qualifying and non-qualifying vulnerabilities can be read on the [bug bounty page](https://yeswehack.com/programs/prestashop).

--- a/content/security/security-policy.md
+++ b/content/security/security-policy.md
@@ -1,0 +1,32 @@
+---
+title: Security policy
+---
+
+# Security Policy
+
+Obviously, PrestaShop project security is a critical matter. PrestaShop teams are dedicated to keep a high level of security in every aspects of the software.
+
+However a software without vulnerability does not exist, which is why there is a security report process. If you find a security issue, please follow it to [responsibly disclose](https://en.wikipedia.org/wiki/Responsible_disclosure) your findings.
+
+## Reporting a Vulnerability
+
+Security issues can be reported by sending an email to security-core@prestashop.com or through our [Bug Bounty Program][bug-bounty], which will go to security team members.
+
+When the security team receives a security bug report, the report will be assigned to a primary handler. 
+This person will coordinate the fix and release process, involving the following steps:
+
+ - Confirm the problem and determine the affected versions.
+ - Audit code to find any potential similar problems.
+ - Prepare fixes for all releases still under maintenance. These fixes will be released as fast as possible.
+
+The security team will follow up with a response indicating the next steps in handling the report.
+
+If the issue is confirmed, the security team will keep you informed of the progress towards a fix and full announcement, and may ask for additional information or guidance.
+
+### Disclosure Policy
+
+In general, public disclosure are made after the issue has been fully identified and a patch is ready to be released.
+
+[bug-bounty]: {{< relref "bug-bounty.md" >}}
+
+

--- a/content/security/security-policy.md
+++ b/content/security/security-policy.md
@@ -4,7 +4,7 @@ title: Security policy
 
 # Security Policy
 
-Obviously, PrestaShop project security is a critical matter. PrestaShop teams are dedicated to keep a high level of security in every aspects of the software.
+Obviously, PrestaShop project security is a critical matter. Project members are dedicated to keeping a high level of security in every aspect of the software.
 
 However a software without vulnerability does not exist, which is why there is a security report process. If you find a security issue, please follow it to [responsibly disclose](https://en.wikipedia.org/wiki/Responsible_disclosure) your findings.
 

--- a/content/security/security-release-process.md
+++ b/content/security/security-release-process.md
@@ -6,9 +6,9 @@ title: Security release process
 
 Here is a short summary of the steps followed by the security team:
 
-1) Security issues is reported to security-core@prestashop.com or through the [Bug Bounty Program][bug-bounty].
+1) Security issues are reported to security-core@prestashop.com or through the [Bug Bounty Program][bug-bounty].
 
-2) Security issues is assessed to identify their criticality level.
+2) Security issues are assessed to identify their criticality level.
 
 - Minor issues are scoped to be fixed in the next scheduled minor release
 - Critical issues are scoped to be fixed as soon as possible
@@ -16,8 +16,8 @@ Here is a short summary of the steps followed by the security team:
 3) For both minor and critical issues, a [GitHub Security Advisory](https://help.github.com/en/github/managing-security-vulnerabilities/creating-a-security-advisory
 ) will be created to register the issue in GitHub CVE database.
 
-4) A [Private Security Fork](https://docs.github.com/en/github/managing-security-vulnerabilities/collaborating-in-a-temporary-private-fork-to-resolve-a-security-vulnerability) is used to prepare a patch Pull Request for the advisory. The Pull Request then reviewed and tested by QA.
+4) A [Private Security Fork](https://docs.github.com/en/github/managing-security-vulnerabilities/collaborating-in-a-temporary-private-fork-to-resolve-a-security-vulnerability) is used to prepare a patch Pull Request for the advisory. The Pull Request is then reviewed and tested by QA.
 
-5) When all patch Pull Requests are ready (in the event that multiple issues are reported), they are all merged and a new patch release is built and delivered. Security Advisories are published and the vulnerabilities are disclosed in a Release Note, urging all PrestaShop users to upgrade in order to protect their shops.
+5) When all patch Pull Requests are ready (in the event that multiple issues are reported), they are all merged, and a new patch release is built and delivered. Security Advisories are published, and the vulnerabilities are disclosed in a Release Note, urging all PrestaShop users to upgrade in order to protect their shops.
 
 [bug-bounty]: {{< relref "bug-bounty.md" >}}

--- a/content/security/security-release-process.md
+++ b/content/security/security-release-process.md
@@ -1,0 +1,23 @@
+---
+title: Security release process
+---
+
+# Security release process
+
+Here is a short summary of the steps followed by the security team:
+
+1) Security issues is reported to security-core@prestashop.com or through the [Bug Bounty Program][bug-bounty].
+
+2) Security issues is assessed to identify their criticality level.
+
+- Minor issues are scoped to be fixed in the next scheduled minor release
+- Critical issues are scoped to be fixed as soon as possible
+
+3) For both minor and critical issues, a [GitHub Security Advisory](https://help.github.com/en/github/managing-security-vulnerabilities/creating-a-security-advisory
+) will be created to register the issue in GitHub CVE database.
+
+4) A [Private Security Fork](https://docs.github.com/en/github/managing-security-vulnerabilities/collaborating-in-a-temporary-private-fork-to-resolve-a-security-vulnerability) is used to prepare a patch Pull Request for the advisory. The Pull Request then reviewed and tested by QA.
+
+5) When all patch Pull Requests are ready (in the event that multiple issues are reported), they are all merged and a new patch release is built and delivered. Security Advisories are published and the vulnerabilities are disclosed in a Release Note, urging all PrestaShop users to upgrade in order to protect their shops.
+
+[bug-bounty]: {{< relref "bug-bounty.md" >}}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop Project Site! 

Please take the time to edit the "Answers" rows below with the necessary information.
Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you!
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description  | Add security section. See below
| Fixed ticket | 

## Description

I add a Security section that
- replaces https://devdocs.prestashop-project.org/8/project/security-policy/ (I will create a redirect PR after this PR is merged)
- provides a page for the bug bounty
- announces the bug bounty is currently on pause

After this PR is merged I will update all places where we refer to the bug bounty to redirect them to this page.