### PR TITLE
Add jokesterfr to committers

### DIFF
--- a/content/project-organization/people-and-roles.md
+++ b/content/project-organization/people-and-roles.md
@@ -63,6 +63,7 @@ Current committers:
 - Leemyongpakvn ([@leemyongpakvn](https://github.com/leemyongpakvn))
 - Thomas Leone ([@tleon](https://github.com/tleon))
 - Guyomar Alexis ([@ga-devfront](https://github.com/ga-devfront))
+- Clément Désiles ([@jokesterfr](https://github.com/jokesterfr))
 
 ### UX Designers
 


### PR DESCRIPTION
I’ve been discussing with @jokesterfr and he’s doing a lot of interesting things with Docker. He for example built this https://github.com/PrestaShopCorp/prestashop-flashlight/ and is willing to give it to the OSS org as he thinks it can be very useful.

He is experienced in running PrestaShop with docker.


We had interesting discussions about topics like https://github.com/PrestaShop/docker/pull/280, missing docker tags on the docker hub, improving PrestaShop docker images...

Given his interest for Docker related topics and his motivation, I suggested welcoming him as committer as it could be helpful for the project especially for the repository https://github.com/PrestaShop/docker/.

3 members of the tech council agreed to this idea which is enough according to [our rules](https://www.prestashop-project.org/maintainers-guide/how-to-become-a-committer/) to validate this application.