### PR TITLE
Slack docs url fix

### DIFF
--- a/config/_default/params.yml
+++ b/config/_default/params.yml
@@ -21,7 +21,7 @@ pluralizeListTitles: false
 projectUrls:
     gitHub: "https://github.com/PrestaShop/PrestaShop/"
     reportBug: "https://github.com/PrestaShop/PrestaShop/issues"
-    slack: "https://github.com/PrestaShop/open-source/blob/master/slack/readme.md"
+    slack: "https://github.com/PrestaShop/open-source/blob/master/content/slack/_index.md"
 
 devdocs: "https://devdocs.prestashop-project.org"
 

--- a/content/slack/channels.md
+++ b/content/slack/channels.md
@@ -6,7 +6,7 @@ title: Slack channels
 
 A Slack dedicated to the PrestaShop open source project is now available. Its purpose is to foster the development of the software and of its ecosystem. The current priority is to configure channels for development and product management purpose. Once done, it will be open more progressively to other needs, like community management, business, etc.
 
-[More information about prestashop.slack.com](https://github.com/PrestaShop/open-source/blob/master/slack/readme.md)
+[More information about prestashop.slack.com](https://github.com/PrestaShop/open-source/blob/master/content/slack/_index.md)
 
 ## Request a new channel
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop Project Site! 

Please take the time to edit the "Answers" rows below with the necessary information.
Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you!
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description  | Fix slack url in documentation. 
| Fixed ticket | No issue but we had discussed it with @matks https://prestashop.slack.com/archives/CTKG1NKAP/p1694590478866929