### PR TITLE
Remove myself

### DIFF
--- a/content/project-organization/people-and-roles.md
+++ b/content/project-organization/people-and-roles.md
@@ -29,7 +29,6 @@ The product council is in charge of product vision for the project, ensuring tha
 Current members:
 
 - Amine Ouanes ([@amine-O](https://github.com/amine-O)) - **Council Lead**
-- Daniel Hlavacek ([@Hlavtox](https://github.com/Hlavtox)) - external contributor not affiliated with PrestaShop SA
 - Iliès Bahloul ([@ibahloul-ps](https://github.com/ibahloul-ps))
 - Jean-François Viguier ([@jf-viguier](https://github.com/jf-viguier)) - external contributor not affiliated with PrestaShop SA
 - Krystian Podemski ([@kpodemski](https://github.com/kpodemski))
@@ -67,7 +66,6 @@ The technical council provides the technical vision for the whole project, revie
 Current members:
 
 - Jonathan Lelièvre ([@jolelievre](https://github.com/jolelievre)) - **Council Lead**
-- Daniel Hlavacek ([@Hlavtox](https://github.com/Hlavtox))
 - Krystian Podemski ([@kpodemski](https://github.com/kpodemski))
 - Mathieu Ferment ([@matks](https://github.com/matks))
 - Matthieu Rolland ([@matthieu-rolland](https://github.com/matthieu-rolland))


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description  | Remove myself
| Fixed ticket | 

Allow me to to remove myself from both councils, as they lost their sense, for several reasons:
- In the councils, only people talking there is me to myself and sometimes @kpodemski.
- No technical or product matters are discussed there, every decision is made in private, between the employees of the company.
- Not even a small decision can be made by the people from the council, there is always a confirmation from some employee.
- They have never been really aknowledged from other teams, as they always ping the employees anyway.